### PR TITLE
Replaced `test_motor` w/ `fakeMotionControl`

### DIFF
--- a/src/TutorialModule.cpp
+++ b/src/TutorialModule.cpp
@@ -70,7 +70,7 @@ bool TutorialModule::configure(yarp::os::ResourceFinder &rf)
     // open a dummy fake robot
     yarp::os::Property fakeRobotConfig;
     fakeRobotConfig.put("device",    "controlboardwrapper2");
-    fakeRobotConfig.put("subdevice", "fakeMotor");
+    fakeRobotConfig.put("subdevice", "fakeMotionControl");
     fakeRobotConfig.put("name", "/fakeRobot/head");
     fakeRobot.open(fakeRobotConfig);
 

--- a/src/TutorialModule.cpp
+++ b/src/TutorialModule.cpp
@@ -70,7 +70,7 @@ bool TutorialModule::configure(yarp::os::ResourceFinder &rf)
     // open a dummy fake robot
     yarp::os::Property fakeRobotConfig;
     fakeRobotConfig.put("device",    "controlboardwrapper2");
-    fakeRobotConfig.put("subdevice", "test_motor");
+    fakeRobotConfig.put("subdevice", "fakeMotor");
     fakeRobotConfig.put("name", "/fakeRobot/head");
     fakeRobot.open(fakeRobotConfig);
 


### PR DESCRIPTION
The plugin `test_motor` has been deprecated.

cc @mfussi66.