### PR TITLE
Updated deprecated robotcontrolboard device

### DIFF
--- a/src/TutorialModule.cpp
+++ b/src/TutorialModule.cpp
@@ -69,7 +69,7 @@ bool TutorialModule::configure(yarp::os::ResourceFinder &rf)
 
     // open a dummy fake robot
     yarp::os::Property fakeRobotConfig;
-    fakeRobotConfig.put("device",    "controlboardwrapper2");
+    fakeRobotConfig.put("device",    "controlBoard_nws_yarp");
     fakeRobotConfig.put("subdevice", "fakeMotionControl");
     fakeRobotConfig.put("name", "/fakeRobot/head");
     fakeRobot.open(fakeRobotConfig);


### PR DESCRIPTION
This pr fixes the issue #3 replacing the device `controlboardwrapper2` deprecated in https://github.com/robotology/yarp/discussions/2660